### PR TITLE
fix for when we only have one message type

### DIFF
--- a/yojimbo.cpp
+++ b/yojimbo.cpp
@@ -1202,7 +1202,7 @@ namespace yojimbo
                                                               Message ** & messages, 
                                                               int maxMessagesPerPacket )
     {
-        const int maxMessageType = messageFactory.GetNumTypes() - 1;
+        const int maxMessageType = messageFactory.GetNumTypes();
 
         bool hasMessages = Stream::IsWriting && numMessages != 0;
 
@@ -1320,7 +1320,7 @@ namespace yojimbo
                                                                 int maxMessagesPerPacket, 
                                                                 int maxBlockSize )
     {
-        const int maxMessageType = messageFactory.GetNumTypes() - 1;
+        const int maxMessageType = messageFactory.GetNumTypes();
 
         bool hasMessages = Stream::IsWriting && numMessages != 0;
 
@@ -1404,7 +1404,7 @@ namespace yojimbo
                                                             ChannelPacketData::BlockData & block, 
                                                             const ChannelConfig & channelConfig )
     {
-        const int maxMessageType = messageFactory.GetNumTypes() - 1;
+        const int maxMessageType = messageFactory.GetNumTypes();
 
         serialize_bits( stream, block.messageId, 16 );
 

--- a/yojimbo.cpp
+++ b/yojimbo.cpp
@@ -1202,7 +1202,7 @@ namespace yojimbo
                                                               Message ** & messages, 
                                                               int maxMessagesPerPacket )
     {
-        const int maxMessageType = messageFactory.GetNumTypes();
+        const int maxMessageType = messageFactory.GetNumTypes() - 1;
 
         bool hasMessages = Stream::IsWriting && numMessages != 0;
 
@@ -1320,7 +1320,7 @@ namespace yojimbo
                                                                 int maxMessagesPerPacket, 
                                                                 int maxBlockSize )
     {
-        const int maxMessageType = messageFactory.GetNumTypes();
+        const int maxMessageType = messageFactory.GetNumTypes() - 1;
 
         bool hasMessages = Stream::IsWriting && numMessages != 0;
 
@@ -1404,7 +1404,7 @@ namespace yojimbo
                                                             ChannelPacketData::BlockData & block, 
                                                             const ChannelConfig & channelConfig )
     {
-        const int maxMessageType = messageFactory.GetNumTypes();
+        const int maxMessageType = messageFactory.GetNumTypes() - 1;
 
         serialize_bits( stream, block.messageId, 16 );
 

--- a/yojimbo.h
+++ b/yojimbo.h
@@ -870,11 +870,7 @@ namespace yojimbo
 
     inline int bits_required( uint32_t min, uint32_t max )
     {
-#ifdef __GNUC__
-        return 32 - __builtin_clz( max - min );
-#else // #ifdef __GNUC__
         return ( min == max ) ? 0 : log2( max - min ) + 1;
-#endif // #ifdef __GNUC__
     }
 
     /**
@@ -2098,7 +2094,7 @@ namespace yojimbo
 
         bool SerializeInteger( int32_t value, int32_t min, int32_t max )
         {
-            yojimbo_assert( min < max );
+            yojimbo_assert( min <= max );
             yojimbo_assert( value >= min );
             yojimbo_assert( value <= max );
             const int bits = bits_required( min, max );
@@ -2258,7 +2254,7 @@ namespace yojimbo
 
         bool SerializeInteger( int32_t & value, int32_t min, int32_t max )
         {
-            yojimbo_assert( min < max );
+            yojimbo_assert( min <= max );
             const int bits = bits_required( min, max );
             if ( m_reader.WouldReadPastEnd( bits ) )
                 return false;
@@ -2410,7 +2406,7 @@ namespace yojimbo
         bool SerializeInteger( int32_t value, int32_t min, int32_t max )
         {   
             (void) value;
-            yojimbo_assert( min < max );
+            yojimbo_assert( min <= max );
             yojimbo_assert( value >= min );
             yojimbo_assert( value <= max );
             const int bits = bits_required( min, max );
@@ -2753,7 +2749,7 @@ namespace yojimbo
     #define serialize_int( stream, value, min, max )                    \
         do                                                              \
         {                                                               \
-            yojimbo_assert( min < max );                                \
+            yojimbo_assert( min <= max );                                \
             int32_t int32_value = 0;                                    \
             if ( Stream::IsWriting )                                    \
             {                                                           \
@@ -3342,7 +3338,7 @@ namespace yojimbo
     #define read_int( stream, value, min, max )                                             \
         do                                                                                  \
         {                                                                                   \
-            yojimbo_assert( min < max );                                                    \
+            yojimbo_assert( min <= max );                                                    \
             int32_t int32_value = 0;                                                        \
             if ( !stream.SerializeInteger( int32_value, min, max ) )                        \
             {                                                                               \
@@ -3388,7 +3384,7 @@ namespace yojimbo
     #define write_int( stream, value, min, max )                                            \
         do                                                                                  \
         {                                                                                   \
-            yojimbo_assert( min < max );                                                    \
+            yojimbo_assert( min <= max );                                                    \
             yojimbo_assert( value >= min );                                                 \
             yojimbo_assert( value <= max );                                                 \
             int32_t int32_value = (int32_t) value;                                          \


### PR DESCRIPTION
I'm not sure why, but it looks like the total number of message types was being subtracted by one. if I remove that subtraction, it seems to fix the issue.