### PR TITLE
Upgrade to libsodium 1.0.16, premake5 5.0.0 alpha 13, and speedup Docker image builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ compiler:
   - gcc
 
 install:
-  - wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha10/premake-5.0.0-alpha10-linux.tar.gz -O /tmp/premake5.tar.gz
+  - wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha13/premake-5.0.0-alpha13-linux.tar.gz -O /tmp/premake5.tar.gz
   - tar -zxvf /tmp/premake5.tar.gz
-  - wget https://github.com/jedisct1/libsodium/releases/download/1.0.10/libsodium-1.0.10.tar.gz -O /tmp/libsodium.tar.gz
+  - wget https://github.com/jedisct1/libsodium/releases/download/1.0.16/libsodium-1.0.16.tar.gz -O /tmp/libsodium.tar.gz
   - pushd .
   - cd /tmp
   - tar -zxvf /tmp/libsodium.tar.gz
-  - cd libsodium-1.0.10
+  - cd libsodium-*
   - ./configure
   - make
   - sudo make install
@@ -24,7 +24,7 @@ install:
   - pushd .
   - cd /tmp
   - tar -zxvf mbedtls.tar.gz
-  - cd mbedtls-mbedtls-2.13.0
+  - cd mbedtls-mbedtls-*
   - cmake .
   - make
   - sudo make install

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -3,7 +3,7 @@ Building yojimbo
 
 ## Building on Windows
 
-Download [premake 5](https://premake.github.io/download.html) and copy the **premake5** executable somewhere in your path. Please make sure you have at least premake5 alpha 10.
+Download [premake 5](https://premake.github.io/download.html) and copy the **premake5** executable somewhere in your path. Please make sure you have at least premake5 alpha 13.
 
 You need Visual Studio to build the source code. If you don't have Visual Studio 2015 you can [download the community edition for free](https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx).
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,9 +6,9 @@ WORKDIR /app
 
 RUN apt-get -y update && apt-get install -y wget make g++ dh-autoreconf pkg-config cmake
 
-RUN wget https://github.com/jedisct1/libsodium/releases/download/1.0.10/libsodium-1.0.10.tar.gz && \
-    tar -zxvf libsodium-1.0.10.tar.gz && \
-    cd libsodium-1.0.10 && \
+RUN wget https://github.com/jedisct1/libsodium/releases/download/1.0.16/libsodium-1.0.16.tar.gz && \
+    tar -zxvf libsodium-*.tar.gz && \
+    cd libsodium-* && \
     ./configure && \
     make && make check && \
     make install && \
@@ -16,14 +16,14 @@ RUN wget https://github.com/jedisct1/libsodium/releases/download/1.0.10/libsodiu
     rm -rf libsodium* && \
     ldconfig
 
-RUN wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha10/premake-5.0.0-alpha10-linux.tar.gz && \ 
+RUN wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha13/premake-5.0.0-alpha13-linux.tar.gz && \ 
     tar -zxvf premake-*.tar.gz && \
     rm premake-*.tar.gz && \
     mv premake5 /usr/local/bin
 
 RUN wget https://github.com/ARMmbed/mbedtls/archive/mbedtls-2.13.0.tar.gz && \
-    tar -zxvf mbedtls-2.13.0.tar.gz && \
-    cd mbedtls-mbedtls-2.13.0 && \
+    tar -zxvf mbedtls-*.tar.gz && \
+    cd mbedtls-mbedtls-* && \
     cmake . && \
     make && make install && \
     ldconfig

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN wget https://github.com/jedisct1/libsodium/releases/download/1.0.16/libsodiu
     tar -zxvf libsodium-*.tar.gz && \
     cd libsodium-* && \
     ./configure && \
-    make && make check && \
+    make -j32 && make check && \
     make install && \
     cd .. && \
     rm -rf libsodium* && \
@@ -25,7 +25,7 @@ RUN wget https://github.com/ARMmbed/mbedtls/archive/mbedtls-2.13.0.tar.gz && \
     tar -zxvf mbedtls-*.tar.gz && \
     cd mbedtls-mbedtls-* && \
     cmake . && \
-    make && make install && \
+    make -j32 && make install && \
     ldconfig
 
 ADD yojimbo /app/yojimbo

--- a/matcher/Dockerfile
+++ b/matcher/Dockerfile
@@ -2,9 +2,9 @@ FROM golang
 
 RUN apt-get -y update && apt-get install -y wget make g++ dh-autoreconf pkg-config openssl
 
-RUN wget https://github.com/jedisct1/libsodium/releases/download/1.0.10/libsodium-1.0.10.tar.gz && \
-    tar -zxvf libsodium-1.0.10.tar.gz && \
-    cd libsodium-1.0.10 && \
+RUN wget https://github.com/jedisct1/libsodium/releases/download/1.0.16/libsodium-1.0.16.tar.gz && \
+    tar -zxvf libsodium-*.tar.gz && \
+    cd libsodium-* && \
     ./configure && \
     make && make check && \
     make install && \

--- a/premake5.lua
+++ b/premake5.lua
@@ -8,7 +8,7 @@ solution "Yojimbo"
     language "C++"
     platforms { "x64" }
     configurations { "Debug", "Release" }
-    if os.is "windows" then
+    if os.istarget "windows" then
         includedirs { ".", "./windows", "netcode.io", "reliable.io" }
         libdirs { "./windows" }
     else
@@ -17,7 +17,9 @@ solution "Yojimbo"
     end
     rtti "Off"
     links { libs }
-    flags { "ExtraWarnings", "FloatFast", "EnableSSE2" }
+    warnings "Extra"
+    floatingpoint "Fast"
+    vectorextensions "SSE2"
     configuration "Debug"
         symbols "On"
     configuration "Release"
@@ -61,7 +63,7 @@ project "soak"
     files { "soak.cpp", "shared.h" }
     links { "yojimbo" }
 
-if not os.is "windows" then
+if not os.istarget "windows" then
 
     -- MacOSX and Linux.
     
@@ -414,7 +416,7 @@ newaction
           os.rmdir( v )
         end
 
-        if not os.is "windows" then
+        if not os.istarget "windows" then
             os.execute "find . -name .DS_Store -delete"
             for i,v in ipairs( files_to_delete ) do
               os.execute( "rm -f " .. v )

--- a/valgrind/Dockerfile
+++ b/valgrind/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.9.18
+FROM phusion/baseimage:0.11
 
 CMD ["/sbin/my_init"]
 
@@ -6,9 +6,9 @@ WORKDIR /app
 
 RUN apt-get -y update && apt-get install -y wget make g++ dh-autoreconf pkg-config valgrind cmake
 
-RUN wget https://github.com/jedisct1/libsodium/releases/download/1.0.10/libsodium-1.0.10.tar.gz && \
-    tar -zxvf libsodium-1.0.10.tar.gz && \
-    cd libsodium-1.0.10 && \
+RUN wget https://github.com/jedisct1/libsodium/releases/download/1.0.16/libsodium-1.0.16.tar.gz && \
+    tar -zxvf libsodium-*.tar.gz && \
+    cd libsodium-* && \
     ./configure && \
     make && make check && \
     make install && \
@@ -16,14 +16,14 @@ RUN wget https://github.com/jedisct1/libsodium/releases/download/1.0.10/libsodiu
     rm -rf libsodium* && \
     ldconfig
 
-RUN wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha10/premake-5.0.0-alpha10-linux.tar.gz && \ 
+RUN wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha13/premake-5.0.0-alpha13-linux.tar.gz && \ 
     tar -zxvf premake-*.tar.gz && \
     rm premake-*.tar.gz && \
     mv premake5 /usr/local/bin
 
-RUN wget https://github.com/ARMmbed/mbedtls/archive/mbedtls-2.1.5.tar.gz && \
-    tar -zxvf mbedtls-2.1.5.tar.gz && \
-    cd mbedtls-mbedtls-2.1.5 && \
+RUN wget https://github.com/ARMmbed/mbedtls/archive/mbedtls-2.13.0.tar.gz && \
+    tar -zxvf mbedtls-*.tar.gz && \
+    cd mbedtls-mbedtls-* && \
     cmake . && \
     make && make install && \
     ldconfig

--- a/valgrind/Dockerfile
+++ b/valgrind/Dockerfile
@@ -10,7 +10,7 @@ RUN wget https://github.com/jedisct1/libsodium/releases/download/1.0.16/libsodiu
     tar -zxvf libsodium-*.tar.gz && \
     cd libsodium-* && \
     ./configure && \
-    make && make check && \
+    make -j32 && make check && \
     make install && \
     cd .. && \
     rm -rf libsodium* && \
@@ -25,7 +25,7 @@ RUN wget https://github.com/ARMmbed/mbedtls/archive/mbedtls-2.13.0.tar.gz && \
     tar -zxvf mbedtls-*.tar.gz && \
     cd mbedtls-mbedtls-* && \
     cmake . && \
-    make && make install && \
+    make -j32 && make install && \
     ldconfig
 
 ADD yojimbo /app/yojimbo


### PR DESCRIPTION
- Upgraded libsodium to 1.0.16 (latest current release).
- Upgraded premake5 to 5.0.0 alpha 13 and fixed deprecation warnings
- Use make -j32 in Docker image builds to reduce build time
- Upgrade valgrind/Dockerfile (I missed it in my last set of changes)
- Use wildcard * in Dockerfiles and .travis to reduce version number redundancy (similar to what was done with premake5 before in some of the Dockerfiles).

## Testing Done

### Debian Stretch 9.6
1. premake5 --version (Premake Build Script Generator) 5.0.0-alpha13
1. premake5 clean
1. premake5 gmake
1. make
1. bin/test (ALL TESTS PASS)
1. premake5 valgrind (ALL TESTS PASS) (no leaks, ERROR SUMMARY: 40 errors from 5 contexts (suppressed: 0 from 0)). Full report here: [valgrind result.txt](https://github.com/networkprotocol/yojimbo/files/2583019/valgrind.result.txt)
1. premake5 docker, in another terminal./bin/client, was able to connect
1. premake5 matcher, in another terminal ./bin/secure_server, in another terminal ./bin/secure_client, was able to connect

### Windows 10

1. premake5 --version (Premake Build Script Generator) 5.0.0-alpha13
1. premake5 clean
1. premake5 vs2017
1. open Yojimbo.sln
1. Debug build solution (Build: 9 succeeded, 0 failed, 0 up-to-date, 0 skipped)
1. .\bin\x64\Debug\test.exe (ALL TESTS PASS)
1. Release build solution (Build: 9 succeeded, 0 failed, 0 up-to-date, 0 skipped)
1. .\bin\x64\Release\test.exe (ALL TESTS PASS)

