### PR TITLE
public HasMessagesToSend, unused field, fixed an assertion

### DIFF
--- a/yojimbo.cpp
+++ b/yojimbo.cpp
@@ -1586,7 +1586,7 @@ namespace yojimbo
 
         if ( !config.disableBlocks )
         {
-            m_sendBlock = YOJIMBO_NEW( *m_allocator, SendBlockData, *m_allocator, m_config.maxBlockSize, m_config.GetMaxFragmentsPerBlock() ); 
+            m_sendBlock = YOJIMBO_NEW( *m_allocator, SendBlockData, *m_allocator, m_config.GetMaxFragmentsPerBlock() ); 
             m_receiveBlock = YOJIMBO_NEW( *m_allocator, ReceiveBlockData, *m_allocator, m_config.maxBlockSize, m_config.GetMaxFragmentsPerBlock() );
         }
         else

--- a/yojimbo.cpp
+++ b/yojimbo.cpp
@@ -2349,6 +2349,12 @@ namespace yojimbo
         return !m_messageSendQueue->IsFull();
     }
 
+    bool UnreliableUnorderedChannel::HasMessagesToSend() const
+    {
+        yojimbo_assert( m_messageSendQueue );
+        return !m_messageSendQueue->IsEmpty();
+    }
+
     void UnreliableUnorderedChannel::SendMessage( Message * message, void *context )
     {
         yojimbo_assert( message );
@@ -2684,6 +2690,12 @@ namespace yojimbo
         yojimbo_assert( channelIndex >= 0 );
         yojimbo_assert( channelIndex < m_connectionConfig.numChannels );
         return m_channel[channelIndex]->CanSendMessage();
+    }
+
+    bool Connection::HasMessagesToSend( int channelIndex ) const {
+        yojimbo_assert( channelIndex >= 0 );
+        yojimbo_assert( channelIndex < m_connectionConfig.numChannels );
+        return m_channel[channelIndex]->HasMessagesToSend();
     }
 
     void Connection::SendMessage( int channelIndex, Message * message, void *context)
@@ -3093,6 +3105,12 @@ namespace yojimbo
     {
         yojimbo_assert( m_connection );
         return m_connection->CanSendMessage( channelIndex );
+    }
+
+    bool BaseClient::HasMessagesToSend( int channelIndex ) const
+    {
+        yojimbo_assert( m_connection );
+        return m_connection->HasMessagesToSend( channelIndex );
     }
 
     void BaseClient::SendMessage( int channelIndex, Message * message )
@@ -3626,6 +3644,14 @@ namespace yojimbo
         yojimbo_assert( clientIndex < m_maxClients );
         yojimbo_assert( m_clientConnection[clientIndex] );
         return m_clientConnection[clientIndex]->CanSendMessage( channelIndex );
+    }
+
+    bool BaseServer::HasMessagesToSend( int clientIndex, int channelIndex ) const
+    {
+        yojimbo_assert( clientIndex >= 0 );
+        yojimbo_assert( clientIndex < m_maxClients );
+        yojimbo_assert( m_clientConnection[clientIndex] );
+        return m_clientConnection[clientIndex]->HasMessagesToSend( channelIndex );
     }
 
     void BaseServer::SendMessage( int clientIndex, int channelIndex, Message * message )

--- a/yojimbo.h
+++ b/yojimbo.h
@@ -2965,7 +2965,7 @@ namespace yojimbo
         if ( Stream::IsWriting )
         {
             length = (int) strlen( string );
-            yojimbo_assert( length < buffer_size - 1 );
+            yojimbo_assert( length < buffer_size );
         }
         serialize_int( stream, length, 0, buffer_size - 1 );
         serialize_bytes( stream, (uint8_t*)string, length );

--- a/yojimbo.h
+++ b/yojimbo.h
@@ -4462,22 +4462,19 @@ namespace yojimbo
 
         struct SendBlockData
         {
-            SendBlockData( Allocator & allocator, int maxBlockSize, int maxFragmentsPerBlock )
+            SendBlockData( Allocator & allocator, int maxFragmentsPerBlock )
             {
                 m_allocator = &allocator;
                 ackedFragment = YOJIMBO_NEW( allocator, BitArray, allocator, maxFragmentsPerBlock );
                 fragmentSendTime = (double*) YOJIMBO_ALLOCATE( allocator, sizeof( double) * maxFragmentsPerBlock );
-                blockData = (uint8_t*) YOJIMBO_ALLOCATE( allocator, maxBlockSize );
                 yojimbo_assert( ackedFragment );
                 yojimbo_assert( fragmentSendTime );
-                yojimbo_assert( blockData );
                 Reset();
             }
 
             ~SendBlockData()
             {
                 YOJIMBO_DELETE( *m_allocator, BitArray, ackedFragment );
-                YOJIMBO_FREE( *m_allocator, blockData );
                 YOJIMBO_FREE( *m_allocator, fragmentSendTime );
             }
 
@@ -4497,7 +4494,6 @@ namespace yojimbo
             uint16_t blockMessageId;                                                    ///< The message id the block is attached to.
             BitArray * ackedFragment;                                                   ///< Has fragment n been received?
             double * fragmentSendTime;                                                  ///< Last time fragment was sent.
-            uint8_t * blockData;                                                        ///< The block data.
 
         private:
 

--- a/yojimbo.h
+++ b/yojimbo.h
@@ -4121,6 +4121,13 @@ namespace yojimbo
         virtual bool CanSendMessage() const = 0;
 
         /**
+            Are there any messages in the send queue?
+            @returns True if there is at least one message in the send queue.            
+         */
+
+         virtual bool HasMessagesToSend() const = 0;
+
+        /**
             Queue a message to be sent across this channel.
             @param message The message to be sent.
          */
@@ -4603,6 +4610,8 @@ namespace yojimbo
 
         bool CanSendMessage() const;
 
+        bool HasMessagesToSend() const;
+
         void SendMessage( Message * message, void *context );
 
         Message * ReceiveMessage();
@@ -4653,6 +4662,8 @@ namespace yojimbo
         void Reset();
 
         bool CanSendMessage( int channelIndex ) const;
+
+        bool HasMessagesToSend( int channelIndex ) const;
 
         void SendMessage( int channelIndex, Message * message, void *context = 0);
 
@@ -5237,6 +5248,8 @@ namespace yojimbo
 
         bool CanSendMessage( int clientIndex, int channelIndex ) const;
 
+        bool HasMessagesToSend( int clientIndex, int channelIndex ) const;
+
         void SendMessage( int clientIndex, int channelIndex, Message * message );
 
         Message * ReceiveMessage( int clientIndex, int channelIndex );
@@ -5639,6 +5652,8 @@ namespace yojimbo
         void FreeBlock( uint8_t * block );
 
         bool CanSendMessage( int channelIndex ) const;
+
+        bool HasMessagesToSend( int channelIndex ) const;
 
         void SendMessage( int channelIndex, Message * message );
 


### PR DESCRIPTION
Hello Glenn,

I'm currently testing yojimbo for my top-down shooter as it looks like a really solid network stack.
I already did some gameplay tests and I think I'll stay with this library for quite some time to come!
I made some commits along the way that I think could perhaps be useful.

The first commit makes the channels' ``HasMessagesToSend`` methods accessible to the library's user 
the same way that ``CanSendMessage`` methods are. 
One use-case I can think of if is the initial state of the world is reaally huge, say, it takes several seconds to transfer. 
The next server update, whether it's a delta-compressed snapshot or a list of inputs - 
might grow so huge during the initial transfer that it's probably best sent using another block message, so the server would simply check if the initial block has gotten through using ``HasMessagesToSend``, and if it did, send a correction that will get through a lot faster, and only then begin to send regular messages.

The second commit removes an unused field, which is ``blockData`` inside the ``SendBlockData``. It compiles just fine without the field, and it's quite logical not to need it - as far as I understand, it is the library's user that allocates the necessary memory for the block through ``AllocateBlock``, and later fills that memory. This is in contrast to ``ReceiveBlockData``, which needs a working space ready whenever a block starts coming in.

The third commit is self-explanatory.
The tests pass - at least for me!

Cheers!
