### PR TITLE
docs: fix simple typo, interoperatibility -> interoperability

### DIFF
--- a/windows/sodium/crypto_hash.h
+++ b/windows/sodium/crypto_hash.h
@@ -2,7 +2,7 @@
 #define crypto_hash_H
 
 /*
- * WARNING: Unless you absolutely need to use SHA512 for interoperatibility,
+ * WARNING: Unless you absolutely need to use SHA512 for interoperability,
  * purposes, you might want to consider crypto_generichash() instead.
  * Unlike SHA512, crypto_generichash() is not vulnerable to length
  * extension attacks.

--- a/windows/sodium/crypto_hash_sha256.h
+++ b/windows/sodium/crypto_hash_sha256.h
@@ -2,7 +2,7 @@
 #define crypto_hash_sha256_H
 
 /*
- * WARNING: Unless you absolutely need to use SHA256 for interoperatibility,
+ * WARNING: Unless you absolutely need to use SHA256 for interoperability,
  * purposes, you might want to consider crypto_generichash() instead.
  * Unlike SHA256, crypto_generichash() is not vulnerable to length
  * extension attacks.

--- a/windows/sodium/crypto_hash_sha512.h
+++ b/windows/sodium/crypto_hash_sha512.h
@@ -2,7 +2,7 @@
 #define crypto_hash_sha512_H
 
 /*
- * WARNING: Unless you absolutely need to use SHA512 for interoperatibility,
+ * WARNING: Unless you absolutely need to use SHA512 for interoperability,
  * purposes, you might want to consider crypto_generichash() instead.
  * Unlike SHA512, crypto_generichash() is not vulnerable to length
  * extension attacks.


### PR DESCRIPTION
There is a small typo in windows/sodium/crypto_hash.h, windows/sodium/crypto_hash_sha256.h, windows/sodium/crypto_hash_sha512.h.

Should read `interoperability` rather than `interoperatibility`.

