### PR TITLE
Add Server::GetClientAddress

### DIFF
--- a/yojimbo.cpp
+++ b/yojimbo.cpp
@@ -3904,6 +3904,11 @@ namespace yojimbo
         return netcode_server_client_id( m_server, clientIndex );
     }
 
+    netcode_address_t * Server::GetClientAddress( int clientIndex ) const
+    {
+        return netcode_server_client_address( m_server, clientIndex );
+    }
+
     int Server::GetNumConnectedClients() const
     {
         return netcode_server_num_connected_clients( m_server );

--- a/yojimbo.h
+++ b/yojimbo.h
@@ -151,6 +151,7 @@
 #undef SendMessage
 #endif
 
+struct netcode_address_t;
 struct netcode_server_t;
 struct netcode_client_t;
 struct reliable_endpoint_t;
@@ -5242,6 +5243,14 @@ namespace yojimbo
 
         virtual uint64_t GetClientId( int clientIndex ) const = 0;
 
+        /**
+            Get the address of the client
+            @param clientIndex the index of the client slot in [0,maxClients-1], where maxClients corresponds to the value passed into the last call to Server::Start.
+            @returns The address of the client.
+         */
+
+        virtual netcode_address_t * GetClientAddress( int clientIndex ) const = 0;
+
         /** 
             Get the number of clients that are currently connected to the server.
             @returns the number of connected clients.
@@ -5508,6 +5517,8 @@ namespace yojimbo
         bool IsClientConnected( int clientIndex ) const;
 
         uint64_t GetClientId( int clientIndex ) const;
+
+        netcode_address_t * GetClientAddress( int clientIndex ) const;
 
         int GetNumConnectedClients() const;
 


### PR DESCRIPTION
This just calls the already existing netcode_server_client_address.

This is similar to the already existing Server::GetClientId.

Feel free to close if no one wants this feature, but I needed it so I figured I'd put it here.
