### PR TITLE
Project specific debug defines

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -22,9 +22,10 @@ solution "Yojimbo"
     vectorextensions "SSE2"
     configuration "Debug"
         symbols "On"
+        defines { "YOJIMBO_DEBUG" }
     configuration "Release"
         optimize "Speed"
-        defines { "NDEBUG" }
+        defines { "YOJIMBO_RELEASE" }
         
 project "test"
     files { "test.cpp" }

--- a/premake5.lua
+++ b/premake5.lua
@@ -22,10 +22,10 @@ solution "Yojimbo"
     vectorextensions "SSE2"
     configuration "Debug"
         symbols "On"
-        defines { "YOJIMBO_DEBUG" }
+        defines { "YOJIMBO_DEBUG", "NETCODE_DEBUG", "RELIABLE_DEBUG" }
     configuration "Release"
         optimize "Speed"
-        defines { "YOJIMBO_RELEASE" }
+        defines { "YOJIMBO_RELEASE", "NETCODE_RELEASE", "RELIABLE_RELEASE" }
         
 project "test"
     files { "test.cpp" }

--- a/yojimbo.h
+++ b/yojimbo.h
@@ -35,6 +35,16 @@
 #define YOJIMBO_MINOR_VERSION 0
 #define YOJIMBO_PATCH_VERSION 0
 
+#if !defined(YOJIMBO_DEBUG) && !defined(YOJIMBO_RELEASE)
+#if defined(NDEBUG)
+#define YOJIMBO_RELEASE
+#else
+#define YOJIMBO_DEBUG
+#endif
+#elif defined(YOJIMBO_DEBUG) && defined(YOJIMBO_RELEASE)
+#error Can only define one of debug & release
+#endif
+
 #if !defined (YOJIMBO_LITTLE_ENDIAN ) && !defined( YOJIMBO_BIG_ENDIAN )
 
   #ifdef __BYTE_ORDER__
@@ -117,19 +127,19 @@
 
 #define YOJIMBO_SERIALIZE_CHECKS                    1
 
-#ifndef NDEBUG
+#ifdef YOJIMBO_DEBUG
 
 #define YOJIMBO_DEBUG_MEMORY_LEAKS                  1
 #define YOJIMBO_DEBUG_MESSAGE_LEAKS                 1
 #define YOJIMBO_DEBUG_MESSAGE_BUDGET                1
 
-#else // #ifndef NDEBUG
+#else // #ifdef YOJIMBO_DEBUG
 
 #define YOJIMBO_DEBUG_MEMORY_LEAKS                  0
 #define YOJIMBO_DEBUG_MESSAGE_LEAKS                 0
 #define YOJIMBO_DEBUG_MESSAGE_BUDGET                0
 
-#endif // #ifndef NDEBUG
+#endif // #ifdef YOJIMBO_DEBUG
 
 #define YOJIMBO_ENABLE_LOGGING                      1
 
@@ -426,7 +436,7 @@ extern void (*yojimbo_assert_function)( const char *, const char *, const char *
     @see yojimbo_set_assert_functio
  */
 
-#ifndef NDEBUG
+#ifdef YOJIMBO_DEBUG
 #define yojimbo_assert( condition )                                                         \
 do                                                                                          \
 {                                                                                           \
@@ -1821,11 +1831,11 @@ namespace yojimbo
             @see BitWriter
          */
 
-#ifndef NDEBUG
+#ifdef YOJIMBO_DEBUG
         BitReader( const void * data, int bytes ) : m_data( (const uint32_t*) data ), m_numBytes( bytes ), m_numWords( ( bytes + 3 ) / 4)
-#else // #ifndef NDEBUG
+#else // #ifdef YOJIMBO_DEBUG
         BitReader( const void * data, int bytes ) : m_data( (const uint32_t*) data ), m_numBytes( bytes )
-#endif // #ifndef NDEBUG
+#endif // #ifdef YOJIMBO_DEBUG
         {
             yojimbo_assert( data );
             m_numBits = m_numBytes * 8;
@@ -1987,9 +1997,9 @@ namespace yojimbo
         uint64_t m_scratch;                 ///< The scratch value. New data is read in 32 bits at a top to the left of this buffer, and data is read off to the right.
         int m_numBits;                      ///< Number of bits to read in the buffer. Of course, we can't *really* know this so it's actually m_numBytes * 8.
         int m_numBytes;                     ///< Number of bytes to read in the buffer. We know this, and this is the non-rounded up version.
-#ifndef NDEBUG
+#ifdef YOJIMBO_DEBUG
         int m_numWords;                     ///< Number of words to read in the buffer. This is rounded up to the next word if necessary.
-#endif // #ifndef NDEBUG
+#endif // #ifdef YOJIMBO_DEBUG
         int m_bitsRead;                     ///< Number of bits read from the buffer so far.
         int m_scratchBits;                  ///< Number of bits currently in the scratch value. If the user wants to read more bits than this, we have to go fetch another dword from memory.
         int m_wordIndex;                    ///< Index of the next word to read from memory.


### PR DESCRIPTION
This and the other two pull requests (https://github.com/networkprotocol/reliable/pull/25 and https://github.com/networkprotocol/netcode/pull/105) are useful because we're trying to fit yojimbo into an Unreal project, which always defines `NDEBUG` if you're using the release CRT. We'd like to be able to take advantage of debug features in yojimbo, so if there are separate debug (and release) flags for the projects, we can define these without modifying the engine.

In addition, these pull requests should all be no-op for existing users -- if you don't define the _DEBUG or _RELEASE symbols, we fall back to using NDEBUG to determine debug status.