### PR TITLE
MBEDTLS3

### DIFF
--- a/secure_client.cpp
+++ b/secure_client.cpp
@@ -30,6 +30,7 @@
 #include <time.h>
 #include <signal.h>
 #include "shared.h"
+#include "certs.h"
 
 using namespace yojimbo;
 
@@ -53,7 +54,7 @@ int ClientMain( int argc, char * argv[] )
 
     Matcher matcher( GetDefaultAllocator() );
 
-    if ( !matcher.Initialize() )
+    if ( !matcher.Initialize((const unsigned char *)&mbedtls_test_cas_pem[0], mbedtls_test_cas_pem_len) )
     {
         printf( "error: failed to initialize matcher\n" );
         return 1;
@@ -61,7 +62,7 @@ int ClientMain( int argc, char * argv[] )
 
     printf( "requesting match from https://localhost:8080\n" );
 
-    matcher.RequestMatch( ProtocolId, clientId, false );
+    matcher.RequestMatch( "localhost", 8080, ProtocolId, clientId, false );
 
     if ( matcher.GetMatchStatus() == MATCH_FAILED )
     {

--- a/yojimbo.cpp
+++ b/yojimbo.cpp
@@ -899,7 +899,7 @@ namespace yojimbo
 #endif // #if YOJIMBO_WITH_MBEDTLS
     }
 
-    bool Matcher::Initialize()
+    bool Matcher::Initialize(const unsigned char * mbedtls_cas_pem, int mbedtls_cas_pem_len)
     {
 #if YOJIMBO_WITH_MBEDTLS
 		
@@ -920,7 +920,7 @@ namespace yojimbo
             return false;
         }
 
-        if ( mbedtls_x509_crt_parse( &m_internal->cacert, (const unsigned char *) mbedtls_test_cas_pem, mbedtls_test_cas_pem_len ) < 0 )
+        if ( mbedtls_x509_crt_parse( &m_internal->cacert, (const unsigned char *) mbedtls_cas_pem, mbedtls_cas_pem_len ) < 0 )
         {
             yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: mbedtls_x509_crt_parse failed (%d)\n", result );
             return false;
@@ -935,7 +935,7 @@ namespace yojimbo
         return true;
     }
 
-    void Matcher::RequestMatch( uint64_t protocolId, uint64_t clientId, bool verifyCertificate )
+    void Matcher::RequestMatch( const char *server_cstr, int port, uint64_t protocolId, uint64_t clientId, bool verifyCertificate )
     {
 #if YOJIMBO_WITH_MBEDTLS
 		
@@ -947,7 +947,10 @@ namespace yojimbo
 
         int result;
 
-        if ( ( result = mbedtls_net_connect( &m_internal->server_fd, SERVER_NAME, SERVER_PORT, MBEDTLS_NET_PROTO_TCP ) ) != 0 )
+        sprintf( request, "%d", port );
+
+
+        if ( ( result = mbedtls_net_connect( &m_internal->server_fd, server_cstr, request, MBEDTLS_NET_PROTO_TCP ) ) != 0 )
         {
             yojimbo_printf( YOJIMBO_LOG_LEVEL_ERROR, "error: mbedtls_net_connect failed (%d)\n", result );
             m_matchStatus = MATCH_FAILED;

--- a/yojimbo.h
+++ b/yojimbo.h
@@ -6037,20 +6037,22 @@ namespace yojimbo
             @returns True if the matcher initialized successfully, false otherwise.
          */
 
-        bool Initialize();
+        bool Initialize(const unsigned char * mbedtls_cas_pem, int mbedtls_cas_pem_len);
 
         /** 
             Request a match.
             This is how clients get connect tokens from matcher.go. 
             They request a match and the server replies with a set of servers to connect to, and a connect token to pass to that server.
             IMPORTANT: This function is currently blocking. It will be made non-blocking in the near future.
+            @param server_cstr the host address of the server
+            @param port Port the server is listening on
             @param protocolId The protocol id that we are using. Used to filter out servers with different protocol versions.
             @param clientId A unique client identifier that identifies each client to your back end services. If you don't have this yet, just roll a random 64 bit number.
             @see Matcher::GetMatchStatus
             @see Matcher::GetConnectToken
          */
 
-        void RequestMatch( uint64_t protocolId, uint64_t clientId, bool verifyCertificate );
+        void RequestMatch( const char *server_cstr, int port,uint64_t protocolId, uint64_t clientId, bool verifyCertificate );
 
         /**
             Get the current match status.


### PR DESCRIPTION
Updated to MBEDTLS3.

- Added define to switch back and forth (Current default is to MBEDTLS3 which loses backwards compatibility)
- Removed reference to two retired headers
- Removed reference to default certificate
- Added certificate as a parameter to the matcher
- Added matcher hostname and port as parameters rather than compiled constants

