### PR TITLE
Replaced tlsf_malloc() with tlsf_memalign(16)

### DIFF
--- a/yojimbo.cpp
+++ b/yojimbo.cpp
@@ -319,7 +319,7 @@ namespace yojimbo
 
     void * TLSF_Allocator::Allocate( size_t size, const char * file, int line )
     {
-        void * p = tlsf_malloc( m_tlsf, size );
+        void * p = tlsf_memalign( m_tlsf, 16, size );
 
         if ( !p )
         {


### PR DESCRIPTION
...since compilers like MSVC assume allocation functions return 16-bit alignment.

This causes issues with messages that have fields aligned (via __declspec() or alignas()) to 16-bytes, since the compiler
assumes allocated structs will be placed on a 16-byte boundary, but tlsf_malloc() only guarantees an 8-byte alignment so
a member declared inside a Yojimbo message with 16-byte alignment might end up at an 8-byte boundary.

This has a tiny cost of the occasional additional 8-bytes of waste per allocation, but in practice I've seen this
to be within noise. Debugging an issue like this might be unobvious for non-senior engineers, so I think the cost is
justified.