### PR TITLE
Fix for YOJIMBO_NEW() null pointer dereference.

### DIFF
--- a/yojimbo.h
+++ b/yojimbo.h
@@ -488,7 +488,10 @@ namespace yojimbo
     class Allocator & GetDefaultAllocator();
 
     /// Macro for creating a new object instance with a yojimbo allocator.
-    #define YOJIMBO_NEW( a, T, ... ) ( new ( (a).Allocate( sizeof(T), __FILE__, __LINE__ ) ) T(__VA_ARGS__) )
+    #define YOJIMBO_NEW( a, T, ... ) ( [&] {void* p; \
+                                    p = (a).Allocate( sizeof(T), __FILE__, __LINE__ ); \
+                                    if (p) {p = new(p) T(__VA_ARGS__);} \
+                                    return static_cast<T*>(p); }())
 
     /// Macro for deleting an object created with a yojimbo allocator.
     #define YOJIMBO_DELETE( a, T, p ) do { if (p) { (p)->~T(); (a).Free( p, __FILE__, __LINE__ ); p = NULL; } } while (0)    


### PR DESCRIPTION
YOJIMBO_DECLARE_MESSAGE_TYPE() expands to:
```
message = YOJIMBO_NEW( allocator, msg_action );
    if ( !message )
        return NULL;
```

But YOJIMBO_NEW() never checks the result from Allocate(), it just
immediately passes it to placement new(), which dereferences a null
pointer if Allocate() fails. This makes it impossible to gracefully
handle OOM situations, and leads to unpreventable crashes.

This change replaces the existing macro with a short lambda evaluated
on the spot that checks for the null pointer and avoids placement new
in OOM situations.