### PR TITLE
Fix YojimboClient state update logic

### DIFF
--- a/yojimbo.cpp
+++ b/yojimbo.cpp
@@ -3301,7 +3301,7 @@ namespace yojimbo
                 Disconnect();
                 SetClientState( CLIENT_STATE_DISCONNECTED );
             }
-            else if ( state == NETCODE_CLIENT_STATE_SENDING_CONNECTION_REQUEST )
+            else if ( state == NETCODE_CLIENT_STATE_SENDING_CONNECTION_REQUEST || state == NETCODE_CLIENT_STATE_SENDING_CONNECTION_RESPONSE )
             {
                 SetClientState( CLIENT_STATE_CONNECTING );
             }


### PR DESCRIPTION
When running some tests I noticed that the `YojimboClient` would sometimes sets its state to `CLIENT_STATE_CONNECTED` before the server would execute the `OnServerClientConnected` callback. Looking at the current logic the `YojimboClient` sets the state to `CLIENT_STATE_CONNECTED` when the netcode state is `NETCODE_CLIENT_STATE_SENDING_CONNECTION_RESPONSE` rather than when it is `NETCODE_CLIENT_STATE_CONNECTED`.

This PR fixes that.